### PR TITLE
Añadido Trigger rellenador de fechas

### DIFF
--- a/TR_ACCESO_EJERCICIO
+++ b/TR_ACCESO_EJERCICIO
@@ -1,0 +1,17 @@
+CREATE OR REPLACE TRIGGER TR_ACCESO_EJERCICIO 
+AFTER INSERT OR UPDATE ON docencia.calif_ejercicio FOR EACH ROW
+DECLARE
+VAR_RETRIBUCION docencia.ejercicio.retribucion%TYPE;
+BEGIN
+  IF INSERTING THEN
+    --Esta situación se dará cuando el profesor asigne ejercicios
+    insert into docencia.audit_ejer values (:new.usuario_usuario_id, :new.ejercicio_ejercicio_id, sysdate, null);
+  ELSIF UPDATING THEN
+    --Sólo cuando ele ejercicio esté correcto.
+    select retribucion into VAR_RETRIBUCION from docencia.ejercicio where ejercicio_id = :new.ejercicio_ejercicio_id;
+    IF :new.nota = VAR_RETRIBUCION THEN
+      --Significa que está correcto.
+      update docencia.audit_ejer set fecha_entrega = sysdate where usuario_id = :new.usuario_usuario_id AND ejercicio_id = :new.ejercicio_ejercicio_id;
+    END IF;
+  END IF;
+END;

--- a/TR_ACCESO_EJERCICIO
+++ b/TR_ACCESO_EJERCICIO
@@ -1,17 +1,22 @@
-CREATE OR REPLACE TRIGGER TR_ACCESO_EJERCICIO 
+create or replace TRIGGER TR_ACCESO_EJERCICIO 
 AFTER INSERT OR UPDATE ON docencia.calif_ejercicio FOR EACH ROW
 DECLARE
 VAR_RETRIBUCION docencia.ejercicio.retribucion%TYPE;
+VAR_FECHA_DOBLE date;
 BEGIN
   IF INSERTING THEN
     --Esta situación se dará cuando el profesor asigne ejercicios
-    insert into docencia.audit_ejer values (:new.usuario_usuario_id, :new.ejercicio_ejercicio_id, sysdate, null);
+    insert into docencia.audit_ejer values (:new.usuario_usuario_id, :new.ejercicio_ejercicio_id, sysdate, null, null);
   ELSIF UPDATING THEN
     --Sólo cuando ele ejercicio esté correcto.
     select retribucion into VAR_RETRIBUCION from docencia.ejercicio where ejercicio_id = :new.ejercicio_ejercicio_id;
     IF :new.nota = VAR_RETRIBUCION THEN
       --Significa que está correcto.
-      update docencia.audit_ejer set fecha_entrega = sysdate where usuario_id = :new.usuario_usuario_id AND ejercicio_id = :new.ejercicio_ejercicio_id;
+      VAR_FECHA_DOBLE := sysdate;
+      update docencia.audit_ejer set fecha_entrega_correcto = VAR_FECHA_DOBLE, fecha_entrega_ultima = VAR_FECHA_DOBLE where usuario_id = :new.usuario_usuario_id AND ejercicio_id = :new.ejercicio_ejercicio_id;
+    ELSE
+    --Estaba incorrecto, ponemos la fecha de que se realizó una entrega, y la correcta a null (se supone el usuario quiso machacar)
+      update docencia.audit_ejer set fecha_entrega_correcto = null, fecha_entrega_ultima = sysdate where usuario_id = :new.usuario_usuario_id AND ejercicio_id = :new.ejercicio_ejercicio_id;
     END IF;
   END IF;
 END;

--- a/TR_ACCESO_EJERCICIO
+++ b/TR_ACCESO_EJERCICIO
@@ -1,22 +1,17 @@
 create or replace TRIGGER TR_ACCESO_EJERCICIO 
-AFTER INSERT OR UPDATE ON docencia.calif_ejercicio FOR EACH ROW
+AFTER UPDATE ON docencia.calif_ejercicio FOR EACH ROW
 DECLARE
 VAR_RETRIBUCION docencia.ejercicio.retribucion%TYPE;
 VAR_FECHA_DOBLE date;
-BEGIN
-  IF INSERTING THEN
-    --Esta situación se dará cuando el profesor asigne ejercicios
-    insert into docencia.audit_ejer values (:new.usuario_usuario_id, :new.ejercicio_ejercicio_id, sysdate, null, null);
-  ELSIF UPDATING THEN
-    --Sólo cuando ele ejercicio esté correcto.
-    select retribucion into VAR_RETRIBUCION from docencia.ejercicio where ejercicio_id = :new.ejercicio_ejercicio_id;
-    IF :new.nota = VAR_RETRIBUCION THEN
-      --Significa que está correcto.
-      VAR_FECHA_DOBLE := sysdate;
-      update docencia.audit_ejer set fecha_entrega_correcto = VAR_FECHA_DOBLE, fecha_entrega_ultima = VAR_FECHA_DOBLE where usuario_id = :new.usuario_usuario_id AND ejercicio_id = :new.ejercicio_ejercicio_id;
-    ELSE
-    --Estaba incorrecto, ponemos la fecha de que se realizó una entrega, y la correcta a null (se supone el usuario quiso machacar)
-      update docencia.audit_ejer set fecha_entrega_correcto = null, fecha_entrega_ultima = sysdate where usuario_id = :new.usuario_usuario_id AND ejercicio_id = :new.ejercicio_ejercicio_id;
-    END IF;
+BEGIN  
+  --Sólo cuando ele ejercicio esté correcto.
+  select retribucion into VAR_RETRIBUCION from docencia.ejercicio where ejercicio_id = :new.ejercicio_ejercicio_id;
+  IF :new.nota = VAR_RETRIBUCION THEN
+    --Significa que está correcto.
+    VAR_FECHA_DOBLE := sysdate;
+    update docencia.audit_ejer set fecha_entrega_correcto = VAR_FECHA_DOBLE, fecha_entrega_ultima = VAR_FECHA_DOBLE where usuario_id = :new.usuario_usuario_id AND ejercicio_id = :new.ejercicio_ejercicio_id;
+  ELSE
+  --no está correcto, solo cambiamos la fecha de ultima entrega
+    update docencia.audit_ejer set fecha_entrega_correcto = null, fecha_entrega_ultima = sysdate where usuario_id = :new.usuario_usuario_id AND ejercicio_id = :new.ejercicio_ejercicio_id;
   END IF;
 END;

--- a/TR_ACCESO_EJERCICIO
+++ b/TR_ACCESO_EJERCICIO
@@ -8,10 +8,10 @@ BEGIN
   select retribucion into VAR_RETRIBUCION from docencia.ejercicio where ejercicio_id = :new.ejercicio_ejercicio_id;
   IF :new.nota = VAR_RETRIBUCION THEN
     --Significa que está correcto.
-    VAR_FECHA_DOBLE := sysdate;
+    VAR_FECHA_DOBLE := systimestamp;
     update docencia.audit_ejer set fecha_entrega_correcto = VAR_FECHA_DOBLE, fecha_entrega_ultima = VAR_FECHA_DOBLE where usuario_id = :new.usuario_usuario_id AND ejercicio_id = :new.ejercicio_ejercicio_id;
   ELSE
   --no está correcto, solo cambiamos la fecha de ultima entrega
-    update docencia.audit_ejer set fecha_entrega_correcto = null, fecha_entrega_ultima = sysdate where usuario_id = :new.usuario_usuario_id AND ejercicio_id = :new.ejercicio_ejercicio_id;
+    update docencia.audit_ejer set fecha_entrega_correcto = null, fecha_entrega_ultima = systimestamp where usuario_id = :new.usuario_usuario_id AND ejercicio_id = :new.ejercicio_ejercicio_id;
   END IF;
 END;

--- a/tablas_auditoria.sql
+++ b/tablas_auditoria.sql
@@ -3,6 +3,7 @@ CREATE TABLE audit_ejer
   usuario_id  NUMBER NOT NULL,
   ejercicio_id NUMBER NOT NULL,
   fecha_inicio DATE NOT NULL,
-  fecha_entrega DATE
+  fecha_entrega_ultima DATE,
+  fecha_entrega_correcto DATE
   );
   ALTER TABLE audit_ejer ADD CONSTRAINT USUARIO_UNIQUE UNIQUE (usuario_id, ejercicio_id);

--- a/tablas_auditoria.sql
+++ b/tablas_auditoria.sql
@@ -2,8 +2,8 @@ CREATE TABLE audit_ejer
   (
   usuario_id  NUMBER NOT NULL,
   ejercicio_id NUMBER NOT NULL,
-  fecha_inicio DATE NOT NULL,
-  fecha_entrega_ultima DATE,
-  fecha_entrega_correcto DATE
+  fecha_inicio TIMESTAMP NOT NULL,
+  fecha_entrega_ultima TIMESTAMP,
+  fecha_entrega_correcto TIMESTAMP
   );
   ALTER TABLE audit_ejer ADD CONSTRAINT USUARIO_UNIQUE UNIQUE (usuario_id, ejercicio_id);


### PR DESCRIPTION
Cuando el profesor asigna un ejercicio (AKA llama al procedimiento que crea una nueva fila en calif_ejercicio) el trigger se dispara y añade el usuario_id, ejercicio_id y fecha de incio.

Cuando el usuario responde y obtiene la nota maxima, el trigger se dispara y actualiza su fila en la tabla de auditoria, añadiendo la fecha_entrega.

Importante, como se crean paquetes de triggers?
@HaritzPuerto 
@FelipeSulser 
@AlvaroFaure 

#83 