### PR TITLE
ahora solo se añade anota como fallo si se actualiza la tabla calif e…

### DIFF
--- a/CORREC_EJER.sql
+++ b/CORREC_EJER.sql
@@ -160,9 +160,11 @@ PACKAGE BODY CORREC_EJER AS
     AND
     ejercicio_ejercicio_id = cor_ejercicio_id;
     
-    update ejercicio
-    set fallos = fallos+1
-    where ejercicio_id = cor_ejercicio_id;
+    IF SQL%ROWCOUNT != 0 THEN
+      update ejercicio
+      set fallos = fallos+1
+      where ejercicio_id = cor_ejercicio_id;
+    END IF;
   END poner_cero;
 
   ---------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
…jercicio con un 0
Si hay un fallo al poner el 0 o el alumno ya tenía un 0, no lo marcamos como si fuera un nuevo fallo.